### PR TITLE
fix: only show 2 pages in the carrousel

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -6,7 +6,7 @@ function mod(n, m) {
 (function () {
 
     let carrousel = 0;
-    const CARROUSEL_LENGTH = 3;
+    const CARROUSEL_LENGTH = 2;
 
     function handleLeft() {
         carrousel = mod(carrousel - 1, CARROUSEL_LENGTH);


### PR DESCRIPTION
Currently only two pages are available, thus resulting in a white page in the carrousel.