### PR TITLE
Add initial implementation of build and deployment workflow

### DIFF
--- a/.github/workflows/build_and_deploy.yaml
+++ b/.github/workflows/build_and_deploy.yaml
@@ -32,7 +32,7 @@ jobs:
         uses: Dylan700/sftp-upload-action@latest
         with:
           username: webstage
-          host: web.ivoa.net
+          server: web.ivoa.net
           dry-run: ${{ env.DRY_RUN }}
           uploads: |
             ./public/ => ./ivoa-web-stage/

--- a/.github/workflows/build_and_deploy.yaml
+++ b/.github/workflows/build_and_deploy.yaml
@@ -1,0 +1,35 @@
+name: "Build and deploy the website"
+
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+      - main
+
+env:
+  HUGO_VERSION: 0.123.4
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Download hugo
+        run: |
+          wget https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_${HUGO_VERSION}_Linux-64bit.tar.gz
+          tar -zxvf hugo_${HUGO_VERSION}_Linux-64bit.tar.gz hugo
+
+      - name: Build the website
+        run: ./hugo
+
+      - name: Deploy the website
+        uses: Dylan700/sftp-upload-action@latest
+        with:
+          username: webstage
+          host: web.ivoa.net
+          uploads: |
+            ./public/ => ./ivoa-web-stage/
+        if: github.event_name != 'pull_request'

--- a/.github/workflows/build_and_deploy.yaml
+++ b/.github/workflows/build_and_deploy.yaml
@@ -25,11 +25,14 @@ jobs:
       - name: Build the website
         run: ./hugo
 
+      - name: Set dry run
+        run: echo "DRY_RUN=${{ github.event_name == 'pull_request' && 'true' || 'false' }}" >> $GITHUB_ENV
+
       - name: Deploy the website
         uses: Dylan700/sftp-upload-action@latest
         with:
           username: webstage
           host: web.ivoa.net
+          dry-run: ${{ env.DRY_RUN }}
           uploads: |
             ./public/ => ./ivoa-web-stage/
-        if: github.event_name != 'pull_request'

--- a/.github/workflows/build_and_deploy.yaml
+++ b/.github/workflows/build_and_deploy.yaml
@@ -34,5 +34,6 @@ jobs:
           username: webstage
           server: web.ivoa.net
           dry-run: ${{ env.DRY_RUN }}
+          key: ${{ secrets.STAGE_ID }}
           uploads: |
             ./public/ => ./ivoa-web-stage/

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@ hugo_stats.json
 
 # tmp hugo file
 .hugo_build.lock
+
+# ignore hugo in case you have installed it in the project directory
+hugo
+hugo*.tar.gz

--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,5 @@ hugo_stats.json
 .hugo_build.lock
 
 # ignore hugo in case you have installed it in the project directory
-hugo
-hugo*.tar.gz
+/hugo
+/hugo*.tar.gz


### PR DESCRIPTION
This workflow has the following features:

- Builds and deploys the website using `hugo`
- When running the action as a PR check, a dry run will be performed on the deployment step.
- The build and deployment action can be manually triggered in the GH actions panel.
- Account and directory information from @molinaro-m is used for the upload.

I don't actually know if the deployment works with the supplied username and target directory - it needs to be tested in GH actions.