### PR TITLE
Partial template for Created and Updated dates

### DIFF
--- a/layouts/partials/page-dates.html
+++ b/layouts/partials/page-dates.html
@@ -1,0 +1,9 @@
+<div class="pageDates">
+    {{- with .Date }}
+    <strong>Created:</strong> <span title="{{ .UTC.Format "January 02, 2006 - 15:04 MST" }}">{{ .Local.Format "January 02, 2006 - 15:04 MST" }}</span>
+    <br/>
+    {{- end }}
+    {{- if gt and .Date (gt (sub .Lastmod.Unix .Date.Unix) 300) }}
+    <strong>Updated:</strong> <span title="{{ .Lastmod.UTC.Format "January 02, 2006 - 15:04 MST" }}">{{ .Lastmod.Local.Format "January 02, 2006 - 15:04 MST" }}</span>
+    {{- end }}
+</div>

--- a/static/css/base.css
+++ b/static/css/base.css
@@ -153,6 +153,16 @@
     line-height: 2rem;
 }
 
+/* === Creation/Update page dates =========================================== */
+
+.pageDates {
+    text-align: right;
+    font-size : .9em;
+    color     : #777;
+    font-style: italic;
+}
+
+
 /* === Footer ============================================ */
 
 .footer {


### PR DESCRIPTION
Add a partial template to add a 'Created' and eventually 'Updated' dates at the

beginning of a page.

For the moment, this is not used. But to integrate this partial in a template file, nothing less simple than inserting the following snippet wherever one wants to add these dates in the final HTML page:

```
{{- partial "page-dates.html" . }}
```

I have also added some simple CSS, but it can obviously be adapted to the IVOA website.