### PR TITLE
Upload the branch version of the website for pull requests

### DIFF
--- a/.github/actions/setup-hugo/action.yaml
+++ b/.github/actions/setup-hugo/action.yaml
@@ -1,0 +1,23 @@
+name: 'Download and extract Hugo'
+description: 'Downloads and extracts a specified version of Hugo'
+inputs:
+  hugo_version:
+    description: 'Version of Hugo to download'
+    required: false
+    default: '0.123.4'
+runs:
+  using: 'composite'
+  steps:
+    - name: Cache Hugo
+      uses: actions/cache@v2
+      with:
+        path: ~/hugo
+        key: ${{ runner.os }}-hugo-${{ inputs.hugo_version }}
+    - name: Download and extract Hugo
+      run: |
+        if [ ! -f ~/hugo ]; then
+          wget https://github.com/gohugoio/hugo/releases/download/v${{ inputs.hugo_version }}/hugo_${{ inputs.hugo_version }}_Linux-64bit.tar.gz
+          tar -zxvf hugo_${{ inputs.hugo_version }}_Linux-64bit.tar.gz
+          mv hugo ~/hugo
+        fi
+      shell: bash

--- a/.github/workflows/deploy_main.yaml
+++ b/.github/workflows/deploy_main.yaml
@@ -6,9 +6,6 @@ on:
     branches:
       - main
 
-env:
-  HUGO_VERSION: 0.123.4
-
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -16,13 +13,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: Download hugo
-        run: |
-          wget https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_${HUGO_VERSION}_Linux-64bit.tar.gz
-          tar -zxvf hugo_${HUGO_VERSION}_Linux-64bit.tar.gz hugo
+      - name: Setup Hugo
+        uses: ./.github/actions/setup-hugo
 
       - name: Build the website
-        run: ./hugo
+        run: ~/hugo
 
       - name: Deploy the website
         uses: Dylan700/sftp-upload-action@latest

--- a/.github/workflows/deploy_main.yaml
+++ b/.github/workflows/deploy_main.yaml
@@ -1,8 +1,7 @@
-name: "Build and deploy the website"
+name: "Deploy the main version of the website"
 
 on:
   workflow_dispatch:
-  pull_request:
   push:
     branches:
       - main
@@ -25,15 +24,11 @@ jobs:
       - name: Build the website
         run: ./hugo
 
-      - name: Set dry run
-        run: echo "DRY_RUN=${{ github.event_name == 'pull_request' && 'true' || 'false' }}" >> $GITHUB_ENV
-
       - name: Deploy the website
         uses: Dylan700/sftp-upload-action@latest
         with:
           username: webstage
           server: web.ivoa.net
-          dry-run: ${{ env.DRY_RUN }}
           key: ${{ secrets.STAGE_ID }}
           uploads: |
             ./public/ => ./ivoa-web-stage/

--- a/.github/workflows/deploy_main.yaml
+++ b/.github/workflows/deploy_main.yaml
@@ -10,7 +10,7 @@ env:
   HUGO_VERSION: 0.123.4
 
 jobs:
-  build:
+  deploy:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/deploy_version.yaml
+++ b/.github/workflows/deploy_version.yaml
@@ -3,9 +3,6 @@ name: "Deploy a branch version of the website"
 on:
   pull_request:
 
-env:
-  HUGO_VERSION: 0.123.4
-
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -21,13 +18,11 @@ jobs:
         shell: bash
         run: echo "BRANCH_NAME=${{ env.BRANCH_NAME }}"
 
-      - name: Download hugo
-        run: |
-          wget https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_${HUGO_VERSION}_Linux-64bit.tar.gz
-          tar -zxvf hugo_${HUGO_VERSION}_Linux-64bit.tar.gz hugo
+      - name: Setup Hugo
+        uses: ./.github/actions/setup-hugo
 
       - name: Build the website
-        run: ./hugo -b https://webtest.ivoa.info/v/${{ env.BRANCH_NAME }}
+        run: ~/hugo -b https://webtest.ivoa.info/v/${{ env.BRANCH_NAME }}
 
       - name: Upload the branch version of the website
         uses: Dylan700/sftp-upload-action@latest

--- a/.github/workflows/deploy_version.yaml
+++ b/.github/workflows/deploy_version.yaml
@@ -7,7 +7,7 @@ env:
   HUGO_VERSION: 0.123.4
 
 jobs:
-  build:
+  deploy:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/deploy_version.yaml
+++ b/.github/workflows/deploy_version.yaml
@@ -1,0 +1,39 @@
+name: "Deploy a branch version of the website"
+
+on:
+  pull_request:
+
+env:
+  HUGO_VERSION: 0.123.4
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Extract branch name
+        shell: bash
+        run: echo "BRANCH_NAME=$(echo ${{ github.head_ref }} | sed 's/\//-/g')" >> $GITHUB_ENV
+
+      - name: Debug print branch name
+        shell: bash
+        run: echo "BRANCH_NAME=${{ env.BRANCH_NAME }}"
+
+      - name: Download hugo
+        run: |
+          wget https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_${HUGO_VERSION}_Linux-64bit.tar.gz
+          tar -zxvf hugo_${HUGO_VERSION}_Linux-64bit.tar.gz hugo
+
+      - name: Build the website
+        run: ./hugo -b https://webtest.ivoa.info/v/${{ env.BRANCH_NAME }}
+
+      - name: Upload the branch version of the website
+        uses: Dylan700/sftp-upload-action@latest
+        with:
+          username: webstage
+          server: web.ivoa.net
+          key: ${{ secrets.STAGE_ID }}
+          uploads: |
+            ./public/ => ./ivoa-web-stage/v/${{ env.BRANCH_NAME }}


### PR DESCRIPTION
This updates the Github actions so that pull requests will deploy the branch's version of the website to `v/${BRANCH_NAME}` under the main site. The base URL is specified using the `-b` command line argument to `hugo` so that links correctly point to the branch version site instead of the main one.

The Github action files were renamed to be clearer and more concise. The `build_main` action will update the main site on merges to `main`. The `build_version` action deploys a pull request's branch changes as described above. The steps for the main workflow were simplified, as the versioned sites are deployed using a totally separate action now, and the dry-run configuration was no longer required.

Additionally, I have added a Github action to setup the `hugo` tool by downloading and adding it to a cache, so that it can be reused in different workflows without requiring setup from scratch every time.

Changes were tested on [this branch](https://webtest.ivoa.info/v/iss10/
) where I verified that the links look correct and point to the versioned site instead of the main site.

The new, simplified workflow for deploying the main site won't trigger until the PR is merged.