### PR TITLE
Add a Makefile to install Hugo and start preview

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,10 @@ hugo_stats.json
 
 # tmp hugo file
 .hugo_build.lock
+/preview/
 
 # ignore hugo in case you have installed it in the project directory
 /hugo
 /hugo*.tar.gz
+/hugo-bin/
+/hugo-bin_old/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,99 @@
+
+BOLD=$(shell tput bold)
+NORMAL=$(shell tput sgr0)
+
+HUGO_URL=https://github.com/gohugoio/hugo/releases/download
+HUGO_VERSION=0.126.1
+HUGO_ARCHIVE=hugo_extended_${HUGO_VERSION}_Linux-64bit.tar.gz
+HUGO_DIR=hugo-bin
+HUGO_DIR_OLD=hugo-bin_old
+HUGO_VERSION_FILE=${HUGO_DIR}/.v${HUGO_VERSION}
+
+HUGO_CMD=${HUGO_DIR}/hugo
+
+.PHONY: help install list-draft uninstall uninstall-hugo preview
+
+#: Display this help (i.e. list all available targets). (DEFAULT TARGET)
+help:
+	@echo
+	@echo "Available targets:"
+	@grep -B1 -E "^[a-zA-Z0-9_-]+\:([^\=]|$$)" Makefile \
+	| grep -v -- -- \
+	| sed 'N;s/\n/###/' \
+	| sed -n "s/^#: \(.*\)###\(.*\):.*/* \2@\1/p" \
+	| fold -s -w 65 \
+	| sed 's/^[ \n\t]*\([^*]\)/@\1/' \
+	| column -t -o '  ' -s '@' \
+	| sed "s/^\* \([a-zA-Z-]\+\) /\n* ${BOLD}\1${NORMAL} /"
+	@echo
+
+
+#: Start the preview service (on port 1313). All required tools are installed/upgraded automatically, when needed.
+preview: install list-draft
+	./local_preview.bash "${HUGO_DIR}"
+
+
+#: List all draft pages (i.e. all pages only visible in preview mode).
+list-draft: install
+	@echo
+	@echo "################################################################################"
+	@echo "                                 DRAFT PAGES"
+	@echo "        (a draft page is never published, but is visible in preview mode)"
+	@echo "--------------------------------------------------------------------------------"
+	@${HUGO_CMD} list drafts | cut -d',' -f1 | tail -n+2
+	@echo "################################################################################"
+	@echo
+
+
+#: Install Hugo (or upgrade it if a different version is set in Makefile).
+install: ${HUGO_VERSION_FILE}
+
+
+${HUGO_VERSION_FILE}:
+	@if [ -d "${HUGO_DIR}" ]; then \
+		echo "- Upgrading Hugo to v${HUGO_VERSION}..."; \
+	else \
+		echo "- Installing Hugo..."; \
+	fi
+	
+	@echo "  - 1/6 - Downloading Hugo (version: ${HUGO_VERSION})..."
+	@wget -q --show-progress "${HUGO_URL}/v${HUGO_VERSION}/${HUGO_ARCHIVE}"
+	
+	@echo "  - 2/6 - Deprecating existing Hugo version..."
+	@if [ -d "${HUGO_DIR}" ]; then \
+		rm -rf "${HUGO_DIR_OLD}"; \
+		mv "${HUGO_DIR}" "${HUGO_DIR_OLD}"; \
+	fi
+
+	@echo "  - 3/6 - Installing Hugo in this directory (inside ${HUGO_DIR})..."
+	@mkdir ${HUGO_DIR} && tar -xzf ${HUGO_ARCHIVE} -C ${HUGO_DIR}/ && rm -f ${HUGO_ARCHIVE}
+
+	@echo "  - 4/6 - Giving execute permission..."
+	@chmod 775 ${HUGO_DIR}/hugo
+
+	@echo "  - 5/6 - Testing installation (and give version)...."
+	@${HUGO_CMD} version
+
+	@echo "  - 6/6 - Removing deprecated Hugo version..."
+	@if [ -d "${HUGO_DIR_OLD}" ]; then \
+		rm -rf "${HUGO_DIR_OLD}"; \
+	fi
+
+	@touch ${HUGO_VERSION_FILE}
+
+
+#: Uninstall Hugo.
+uninstall:
+	@if [ -d "${HUGO_DIR}" ]; then \
+		if read -p "Uninstall Hugo? [Y/n] " confirm ; then \
+			if [ $${confirm:-'Y'} = 'n' ]; then \
+				echo "=> Aborted"; \
+			else \
+				rm -rf ${HUGO_DIR} \
+				&& echo "=> OK. Hugo successfully uninstalled." \
+				|| echo "=> ERROR: Failed to delete the directory '${HUGO_DIR}'!"; \
+			fi \
+		fi \
+	else \
+		echo "INFO: Hugo is not installed. Nothing to do."; \
+	fi

--- a/local_preview.bash
+++ b/local_preview.bash
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+HUGO_DIR="$1"
+
+PORT=1313
+TMP_PREVIEW_DIR=preview
+
+# Search for the best option to open a web browser:
+OPEN_BROWSER=$(which xdg-open || which open || which x-www-browser || which firefox)
+
+# Starting message:
+echo "- Starting preview service..."
+echo "  (rendered pages available in '${TMP_PREVIEW_DIR}/' while the preview is running)"
+echo
+
+# Test whether the preview port is available:
+if nc -z localhost $PORT;
+then
+    echo "  => ERROR: Port $PORT already used! A preview might already be started."
+    
+    # Give the PID of the running Hugo process, if any:
+    if hugoPID=$(pgrep -f 'hugo server');
+    then
+        echo "            (Hugo process found with PID $hugoPID (try 'kill $hugoPID' to close it)"
+    fi
+else
+    # Enable job control (so that being able to start hugo in background and
+    # then put it back in foreground):
+    set -m
+
+    # Delete former preview directory, if any:
+    [ -d "$TMP_PREVIEW_DIR" ] && rm -rf "$TMP_PREVIEW_DIR"
+
+    # Start Hugo in background:
+    "$HUGO_DIR"/hugo server -d "$TMP_PREVIEW_DIR" --watch --port $PORT -DEF --printI18nWarnings &
+
+    # Wait a bit that Hugo starts generating pages (so that we have time to see
+    # whether Hugo is started ; because we cannot get the exit status of a
+    # background process):
+    sleep 1
+
+    # If the preview directory exists, then Hugo is running and...
+    if [ -d "$TMP_PREVIEW_DIR" ]
+    then
+        # If a browser can be opened:
+        if [ -n "$OPEN_BROWSER" ]
+        then
+            # ...open it with the preview home page:
+            exec "$OPEN_BROWSER" 'http://localhost:1313/' >/dev/null 2>&1 &
+        else
+            echo "  => WARNING: no command found to open the preview in a browser!"
+        fi
+
+        # Put back Hugo in foreground:
+        fg %1 >/dev/null
+        
+        # When preview is stopped, delete temporary files
+        # (i.e. generated preview pages):
+        rm -rf "$TMP_PREVIEW_DIR"
+    else
+        echo "  => ERROR: failed to start preview service! (see error above)"
+    fi
+fi


### PR DESCRIPTION
Makefile to perform few Hugo actions. By default, the `make` command returns the following listing of available commands:

```
Available targets:

* help        Display this help (i.e. list all available targets). 
              (DEFAULT TARGET)

* preview     Start the preview service (on port 1313). All required 
              tools are installed/upgraded automatically, when needed.

* list-draft  List all draft pages (i.e. all pages only visible 
              in preview mode).

* install     Install Hugo (or upgrade it if a different version is 
              set in Makefile).

* uninstall   Uninstall Hugo.
```

Fixes #14