### PR TITLE
Change title of list layout and display content

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -1,5 +1,7 @@
 {{ define "main"}}
-<h1>{{ .Title }} List</h1>
+<h1>{{ .Title }}</h1>
+
+{{ .Content }}
 
 {{ range .Pages }}
 <p>


### PR DESCRIPTION
Change to not hardcode "List" after the page title and display page contents, which was missing from the template.