### PR TITLE
Add shortcodes for image placement

### DIFF
--- a/layouts/shortcodes/floating.html
+++ b/layouts/shortcodes/floating.html
@@ -1,0 +1,3 @@
+<div class="{{ if .Get 0 }}floating {{ .Get 0 }}{{ else }}floating{{ end }}">
+    {{ .Inner | markdownify }}
+</div>

--- a/layouts/shortcodes/side-image.html
+++ b/layouts/shortcodes/side-image.html
@@ -1,0 +1,12 @@
+<section class="with-image {{ .Get "position" }}">
+    <aside>
+    {{- if (.Get "thumbnail") }}
+        <a href="{{ .Get "image" }}"><img src="{{- .Get "thumbnail" }}" /></a>
+    {{- else }}
+        <img src="{{- .Get "image" }}" />
+    {{- end }}
+    </aside>
+    <main>
+        {{- .Inner | markdownify }}
+    </main>
+</section>

--- a/static/css/ivoa.css
+++ b/static/css/ivoa.css
@@ -246,6 +246,31 @@ section > main + aside  { margin-left: 1em }
 
 
 /* =============================================================================
+   SECTION WITH A SIDE IMAGE
+ */
+
+.with-image {
+    display              : grid;
+    grid-template-columns: auto 1fr;
+    grid-template-areas  : "image content";
+    column-gap: 1em;
+}
+
+.with-image.right {
+    grid-template-columns: 1fr auto;
+    grid-template-areas  : "content image";
+}
+
+.with-image > aside {
+    grid-area : image;
+    margin-top: 1em;
+}
+
+.with-image > aside > img { max-width: 30vw }
+.with-image > main        { grid-area: content }
+
+
+/* =============================================================================
    CARROUSEL
  */
 

--- a/static/css/ivoa.css
+++ b/static/css/ivoa.css
@@ -21,6 +21,7 @@ body {
 
 h1, h2, h3 {
     color: #012647;
+    clear: both;
 }
 
 body > main > article > header > h1 {
@@ -405,3 +406,19 @@ section > main.carrousel {
 .sitemap .card:nth-child(1) > .card-title { border-bottom-color: #5dbbf5 }
 .sitemap .card:nth-child(2) > .card-title { border-bottom-color: #399110 }
 .sitemap .card:nth-child(3) > .card-title { border-bottom-color: #aa3f3f }
+
+
+/* =============================================================================
+   FLOATING
+ */
+
+.floating {
+    margin: 1em;
+    margin-top: 0;
+}
+.floating.left  { float: left ; margin-left: 0; }
+.floating.right { float: right; margin-right: 0; }
+
+.floating > img {
+    max-width: 30vw;
+}


### PR DESCRIPTION
This PullRequest adds two shortcodes in order to help placing images in a page:

- **`floating.html`:** it is just applying the CSS style `float: left/right` on a given content. This content can be an image but also anything else. It may take one (un-named) parameter: `left` (default) or `right`
  
  Usage example:
  ```
  {{< floating right >}}                                                           
  ![](ivoa_logoc2.jpg)                                                             
  {{</ floating >}}
  ```
- **`side-image`:** this shortcode is entirely dedicated to images.
  
  It takes at least one parameter, the URL of the side image: `image`.
  
  It also accepts another parameter to give the URL of a thumbnail of the image: `thumbnail`. With this additional parameter, the image becomes clickable ; the click leads to the full size image.
  
  A third parameter lets specify whether the side image should be on the left or on the right: `position`. If unspecified, it will be on the left.
  
  The body content of this shortcode, is the content (text or not) to be placed on right or the left of the image.

  Usage example:
  ```
  {{< side-image image="my-image.png" thumbnail="my-image_thumb.png" >}}
  **Super** blabla
  {{</ side-image >}}
  ```
  
  This shortcode could be improved by adding a target URL. Then, the click would not lead to the full size image but to the given URL. The full size image could then be displayed on mouse hover or with a small magnifier button appearing over the image. Similarly, it could be possible to do the same with a figure (then, with a numbered caption) instead of a simple image. All these improvements (and maybe others) can be made later when needed.

Fixes #84 