### PR TITLE
added about/roadmap page

### DIFF
--- a/content/about/roadmap.md
+++ b/content/about/roadmap.md
@@ -1,0 +1,37 @@
+---
+title: "IVOA Roadmap"
+date: 2024-10-28T18:10:54+01:00
+draft: false
+tags:
+- about
+---
+
+Since its formation in 2002, the IVOA can boast of a number of achievements:
+ - Reaching truly world-wide cohesion in debating and agreeing key astronomical standards. 
+The IVOA is endorsed by the International Astronomical Union (IAU) as the accepted method 
+for producing astronomical data-related standards. Our standards are passed on to 
+IAU Commission 5 for ratification.
+ - Establishing a forum for discussing and debating astronomical data technology in general 
+as well VO standards in particular. The twice yearly "Interoperability Meetings" have been 
+a key feature in resolving international differences as well as sharing ideas and technology.
+ - Rapid agreement on an initial set of basic standards - a table exchange format, a specification 
+for simple catalogue and image query services, the definition of metadata describing resources, 
+a dictionary for standardised column names, and a suite of standards allowing the construction 
+of VO registries. Services complying with these initial standards are already deployed around the world. 
+Also very successful has been the definition of a simple standardised way for applications to pass 
+messages between each other, so they can collaborate smoothly on VO tasks. At the time of writing 
+the IVOA has agreed a crucial new standard, the Table Access Protocol, which allows software 
+to send flexible queries to a wide variety of databases.
+
+The IVOA is working hard on further standards, including those needed for virtual storage 
+addressing, single sign on, semantic reasoning, grid and web service modularisation.
+
+The last semestral roadmap document maintained by the TCG is the 2024A
+Roadmap, spanning the time between the May 2024 and November 2024
+Interoperability meetings and can be found
+[here](http://wiki.ivoa.net/twiki/bin/view/IVOA/2024ARoadmap) 
+([Roadmap 2024A](http://wiki.ivoa.net/twiki/bin/view/IVOA/2024ARoadmap)).
+
+All [Technical Roadmap Documents](https://wiki.ivoa.net/twiki/bin/view/IVOA/TCGRoadmaps) 
+can be found at this [wiki page](https://wiki.ivoa.net/twiki/bin/view/IVOA/TCGRoadmaps).
+


### PR DESCRIPTION
Adds a (simplified) [about/roadmap](https://ivoa.net/about/roadmap.html) page in markdown.
It's simplified in the sense that the roadmap listing has been substituted by a wiki page that takes care of the listing itself.