### PR TITLE
Remove extra slash in header links

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -5,10 +5,10 @@
     </a>
     <nav>
         <a href="{{ .Site.Home.Permalink}}">Home</a>
-        <a href="{{ .Site.Home.Permalink}}/astronomers/">Astronomers</a>
-        <a href="{{ .Site.Home.Permalink}}/deployers/">Deployers</a>
-        <a href="{{ .Site.Home.Permalink}}/members/">Members</a>
-        <a href="{{ .Site.Home.Permalink}}/about/">About</a>
-        <a class="search" href="{{ .Site.Home.Permalink}}/search/">Search</a>
+        <a href="{{ .Site.Home.Permalink}}astronomers/">Astronomers</a>
+        <a href="{{ .Site.Home.Permalink}}deployers/">Deployers</a>
+        <a href="{{ .Site.Home.Permalink}}members/">Members</a>
+        <a href="{{ .Site.Home.Permalink}}about/">About</a>
+        <a class="search" href="{{ .Site.Home.Permalink}}search/">Search</a>
     </nav>
 </header>


### PR DESCRIPTION
This PR removes the extra slashes in the header links. This was making the search page not function properly.