### PR TITLE
2025A updates

### DIFF
--- a/content/about/contacts.md
+++ b/content/about/contacts.md
@@ -7,8 +7,8 @@ tags:
 ---
 
 _IVOA Executive Committee_
-- **IVOA Chair**: [Simon O'Toole](mailto:simon.otoole@mq.edu.au)
-- **Deputy Chair**: [JJ Kavelaars](mailto:jj.kavelaars@nrc-cnrc.gc.ca)
+- **IVOA Chair**: [JJ Kavelaars](mailto:jj.kavelaars@nrc-cnrc.gc.ca)
+- **Deputy Chair**: [Mark Allen](mailto:mark.allen@astro.unistra.fr)
 - *Secretary*: [Marcy Harbut](mailto:mharbut@ipac.caltech.edu)
 
 Contacts for the [_IVOA Member Organizations_](../member-contacts)

--- a/content/about/member-contacts.md
+++ b/content/about/member-contacts.md
@@ -22,13 +22,13 @@ tags:
 |  NLVO | [Netherland Virtual Observatory](http://www.virtualobservatory.nl) |  [Yan Grange](mailto:grange@astron.nl) |
 |  JVO | [Japanese Virtual Observatory](http://jvo.nao.ac.jp/) |  [Yuji Shirasaki](mailto:yuji.shirasaki@nao.ac.jp) |
 |  KazVO | [Kazakstan Virtual Observatory](https://fai.kz/) |  [Chingis Omarov](mailto:chingis.omarov@gmail.com) |
-|  OV-France | [Observatoire Virtuel France](http://www.france-vo.org/) |  [Franck Le Petit](mailto:Franck.LePetit@obspm.fr) |
+|  OV-France | [Observatoire Virtuel France](http://www.france-vo.org/) |  [Ada Nebot](mailto:ada.nebot@astro.unistra.fr) |
 |  RVO | [Russian Virtual Observatory](http://www.inasan.rssi.ru/eng/rvo/) |  [Oleg Malkov](mailto:malkov@inasan.ru) |
-|  SA<sup>3</sup> | [South Africa Astroinformatics Alliance](http://www.sa3.ac.za) |  [Patricia Whitelock](mailto:paw@saao.ac.za) |
+|  SA<sup>3</sup> | [South Africa Astroinformatics Alliance](http://www.sa3.ac.za) |  [Encarni Romero Colmenero](mailto:erc@saao.ac.za) |
 |  SKAO | [Square Kilometre Array Observatory](https://www.skao.int/) |  [Antonio Chrysostomou](mailto:Antonio.Chrysostomou@skao.int) |
 |  SVO | [Spanish Virtual Observatory](http://svo.cab.inta-csic.es/) |  [Enrique Solano](mailto:esm@cab.inta-csic.es) |
 |  UkrVO | [Ukrainian Virtual Observatory](http://www.ukr-vo.org) |  [Irina Vavilova](mailto:irivav@MAO.Kiev.UA) |
 |  USVOA | [US Virtual Observatory Alliance](http://usvoa.cfa.harvard.edu) |  [Pepi Fabbiano](mailto:gfabbiano@cfa.harvard.edu) |
-|  VO-India | [Virtual Observatory India](http://vo.iucaa.ernet.in/%7Evoi/) |  [Ajit Kembhavi](mailto:akk@iucaa.ernet.in) |
+|  VO-India | [Virtual Observatory India](http://vo.iucaa.ernet.in/%7Evoi/) |  [Sudhanshu Barway](mailto:sudhanshu.barway@iiap.res.in) |
 |  VObs.it | [Italian Virtual Observatory](http://vobs.it) |  [Marco Molinaro](mailto:marco.molinaro@inaf.it) |
 {{</my-table>}}

--- a/content/about/member-organizations.md
+++ b/content/about/member-organizations.md
@@ -31,7 +31,7 @@ Contact points for the single
 - [Square Kilometer Array Observatory](http://www.skatelescope.org)
 - [South African Astroinformatics Alliance](http://www.sa3.ac.za/)
 - [Spanish Virtual Observatory](http://svo.cab.inta-csic.es/)
-- [Italian Virtual Observatory](http://vobs.astro.it)
+- [Italian Virtual Observatory](https://www.vobs.it/en/)
 - [Ukrainian Virtual Observatory](http://ukr-vo.org)
 - [US Virtual Observatory Alliance](http://usvoa.cfa.harvard.edu)
 - [Virtual Observatory India](http://voi.iucaa.in)

--- a/content/about/roadmap.md
+++ b/content/about/roadmap.md
@@ -26,11 +26,11 @@ to send flexible queries to a wide variety of databases.
 The IVOA is working hard on further standards, including those needed for virtual storage 
 addressing, single sign on, semantic reasoning, grid and web service modularisation.
 
-The last semestral roadmap document maintained by the TCG is the 2024A
-Roadmap, spanning the time between the May 2024 and November 2024
+The last semestral roadmap document maintained by the TCG is the 2025A
+Roadmap, spanning the time between the June 2025 and November 2025
 Interoperability meetings and can be found
-[here](http://wiki.ivoa.net/twiki/bin/view/IVOA/2024ARoadmap) 
-([Roadmap 2024A](http://wiki.ivoa.net/twiki/bin/view/IVOA/2024ARoadmap)).
+[here](http://wiki.ivoa.net/twiki/bin/view/IVOA/2025ARoadmap) 
+([Roadmap 2025A](http://wiki.ivoa.net/twiki/bin/view/IVOA/2025ARoadmap)).
 
 All [Technical Roadmap Documents](https://wiki.ivoa.net/twiki/bin/view/IVOA/TCGRoadmaps) 
 can be found at this [wiki page](https://wiki.ivoa.net/twiki/bin/view/IVOA/TCGRoadmaps).

--- a/content/members/working-groups.md
+++ b/content/members/working-groups.md
@@ -11,10 +11,10 @@ standards documents, etc. The material is intended for people actually
 working on development of IVOA standards, but is open to all, so any
 interested parties are welcome to follow the progress of IVOA business.
 To understand this material, you may first want to peruse the overview
-given in the [Deployers](../deployers) section.
+given in the [Deployers](../../deployers) section.
 
 [Twiki Pages](http://wiki.ivoa.net) | [Documents in
-progress](../documents) | [Meeting
+progress](../../documents) | [Meeting
 Calendar](http://wiki.ivoa.net/twiki/bin/view/IVOA/IvoaEvents)
 
 [IVOA Code of Conduct](IVOA_Code_of_Conduct.pdf)
@@ -32,10 +32,10 @@ The mailing list archive can be searched [here](http://mail.ivoa.net/search).
 {{<my-table>}}
 | Working Group Page | Previous Messages | Subscribe | Send Mail | Chair | Vice Chair |
 | --- | --- | --- | --- | --- | --- |
-| [Applications](http://wiki.ivoa.net/twiki/bin/view/IVOA/IvoaApplications) | [archive](http://mail.ivoa.net/pipermail/apps/) | [options](http://mail.ivoa.net/mailman/listinfo/apps) | [apps@ivoa.net](mailto:apps@ivoa.net) | Pierre Le Sidaner | Adrian Damian |
+| [Applications](http://wiki.ivoa.net/twiki/bin/view/IVOA/IvoaApplications) | [archive](http://mail.ivoa.net/pipermail/apps/) | [options](http://mail.ivoa.net/mailman/listinfo/apps) | [apps@ivoa.net](mailto:apps@ivoa.net) | Adrian Damian | Brigitta Sip&odblac;cz |
 | [Data Access Layer](http://wiki.ivoa.net/twiki/bin/view/IVOA/IvoaDAL) | [archive](http://mail.ivoa.net/pipermail/dal/) | [options](http://mail.ivoa.net/mailman/listinfo/dal) | [dal@ivoa.net](mailto:dal@ivoa.net) | James Dempsey | Gr&eacute;gory Mantelet |
-| [Data Model](http://wiki.ivoa.net/twiki/bin/view/IVOA/IvoaDataModel) | [archive](http://mail.ivoa.net/pipermail/dm/) | [options](http://mail.ivoa.net/mailman/listinfo/dm) | [dm@ivoa.net](mailto:dm@ivoa.net) | Mark Cresitello-Dittmar | MathieuServillat |
-| [Grid &amp; Web Services](http://wiki.ivoa.net/twiki/bin/view/IVOA/IvoaGridAndWebServices) | [archive](http://mail.ivoa.net/pipermail/grid/) | [options](http://mail.ivoa.net/mailman/listinfo/grid) | [grid@ivoa.net](mailto:grid@ivoa.net) | Jesus Salgado | Sara Bertocco |
+| [Data Model](http://wiki.ivoa.net/twiki/bin/view/IVOA/IvoaDataModel) | [archive](http://mail.ivoa.net/pipermail/dm/) | [options](http://mail.ivoa.net/mailman/listinfo/dm) | [dm@ivoa.net](mailto:dm@ivoa.net) | Mark Cresitello-Dittmar | Mathieu Servillat |
+| [Distributed Services &amp; Protocols](http://wiki.ivoa.net/twiki/bin/view/IVOA/DistributedServicesAndProtocols) | [archive](http://mail.ivoa.net/pipermail/dsp/) | [options](http://mail.ivoa.net/mailman/listinfo/dsp) | [dsp@ivoa.net](mailto:grid@ivoa.net) | Jesus Salgado | Sara Bertocco |
 | [Registry](http://wiki.ivoa.net/twiki/bin/view/IVOA/IvoaResReg) | [archive](http://mail.ivoa.net/pipermail/registry/) | [options](http://mail.ivoa.net/mailman/listinfo/registry) | [registry@ivoa.net](mailto:registry@ivoa.net) | Renaud Savalle | Tess Jaffe |
 | [Semantics](http://wiki.ivoa.net/twiki/bin/view/IVOA/IvoaSemantics) | [archive](http://mail.ivoa.net/pipermail/semantics/) | [options](http://mail.ivoa.net/mailman/listinfo/semantics) | [semantics@ivoa.net](mailto:semantics@ivoa.net) | Baptiste Cecconi | Sebastien Derriere |
 {{</my-table>}}
@@ -47,25 +47,28 @@ See the [Policy on IVOA Working Group/Interest Group Chairs and Vice chairs](htt
 | Interest Group Page | Previous Messages | Subscribe | Mailing List | Chair | Vice Chair |
 | --- | --- | --- | --- | --- | --- |
 | [Data Curation & Preservation](http://wiki.ivoa.net/twiki/bin/view/IVOA/IvoaDCP) | [archives](http://mail.ivoa.net/pipermail/datacp/) | [options](http://mail.ivoa.net/mailman/listinfo/datacp) | [datacp@ivoa.net](mailto:datacp@ivoa.net) | Gilles Landais | Gus Muench |
-| [Education](http://wiki.ivoa.net/twiki/bin/view/IVOA/IvoaEducation) | [archives](http://mail.ivoa.net/pipermail/edu/) | [options](http://mail.ivoa.net/mailman/listinfo/edu) | [edu@ivoa.net](mailto:edu@ivoa.net) | Hendrik Heinl | Shanshan Li |
-| [Knowledge Discovery in Databases](http://wiki.ivoa.net/twiki/bin/view/IVOA/IvoaKDD) | [archives](http://mail.ivoa.net/pipermail/kdd/) | [options](http://mail.ivoa.net/mailman/listinfo/kdd) | [kdd@ivoa.net](mailto:kdd@ivoa.net) | Raffaele d'Abrusco | Yihan Tao |
+| [Education](http://wiki.ivoa.net/twiki/bin/view/IVOA/IvoaEducation) | [archives](http://mail.ivoa.net/pipermail/edu/) | [options](http://mail.ivoa.net/mailman/listinfo/edu) | [edu@ivoa.net](mailto:edu@ivoa.net) | Shanshan Li | Jeremy McCormick |
+| [High Energy](https://wiki.ivoa.net/twiki/bin/view/IVOA/HEGroup) | [archives](http://mail.ivoa.net/pipermail/heig/) | [options](http://mail.ivoa.net/mailman/listinfo/heig) | [heig@ivoa.net](mailto:heig@ivoa.net) | Bruno Khelifi | Janet Evans |
+| [Knowledge Discovery](http://wiki.ivoa.net/twiki/bin/view/IVOA/IvoaKDD) | [archives](http://mail.ivoa.net/pipermail/kdd/) | [options](http://mail.ivoa.net/mailman/listinfo/kdd) | [kdd@ivoa.net](mailto:kdd@ivoa.net) | Yihan Tao | Andre Schaaff |
 | [Operations](http://wiki.ivoa.net/twiki/bin/view/IVOA/IvoaOps) | [archives](http://mail.ivoa.net/pipermail/ops/) | [options](http://mail.ivoa.net/mailman/listinfo/ops) | [ops@ivoa.net](mailto:ops@ivoa.net) | Steve Groom | Tamara Civera |
-| [Solar System](http://wiki.ivoa.net/twiki/bin/view/IVOA/IvoaSS) | [archives](http://mail.ivoa.net/pipermail/ssig/) | [options](http://mail.ivoa.net/mailman/listinfo/ssig) | [ssig@ivoa.net](mailto:ssig@ivoa.net) | Anne Raugh | Markus Demleitner |
-| [Theory](http://wiki.ivoa.net/twiki/bin/view/IVOA/IvoaTheory) | [archives](http://mail.ivoa.net/pipermail/theory/) | [options](http://mail.ivoa.net/mailman/listinfo/theory) | [theory@ivoa.net](mailto:theory@ivoa.net) | Simon O’Toole | Giuliano Taffoni |
-| [Time Domain](http://wiki.ivoa.net/twiki/bin/view/IVOA/IvoaVOEvent) | [archives](http://mail.ivoa.net/pipermail/voevent/) | [options](http://mail.ivoa.net/mailman/listinfo/voevent) | [voevent@ivoa.net](mailto:voevent@ivoa.net) | Rafael Martinez Galarzai | Pierre Fernique |
-| [Radio](http://wiki.ivoa.net/twiki/bin/view/IVOA/IvoaRadio) | [archives](http://mail.ivoa.net/pipermail/radioig/) | [options](http://mail.ivoa.net/mailman/listinfo/radioig) | [radioig@ivoa.net](mailto:radio@ivoa.net) | Francois Bonnarel | Mark Kettenis |
-| High Energy | [archives](http://mail.ivoa.net/pipermail/heig/) | [options](http://mail.ivoa.net/mailman/listinfo/heig) | [radioig@ivoa.net](mailto:heig@ivoa.net) | Janet Evans |  |
+| [Radio](http://wiki.ivoa.net/twiki/bin/view/IVOA/IvoaRadio) | [archives](http://mail.ivoa.net/pipermail/radioig/) | [options](http://mail.ivoa.net/mailman/listinfo/radioig) | [radioig@ivoa.net](mailto:radio@ivoa.net) | Mark Kettenis | OPEN |
+| [Solar System](http://wiki.ivoa.net/twiki/bin/view/IVOA/IvoaSS) | [archives](http://mail.ivoa.net/pipermail/ssig/) | [options](http://mail.ivoa.net/mailman/listinfo/ssig) | [ssig@ivoa.net](mailto:ssig@ivoa.net) | TBA | Markus Demleitner |
+| [Time Domain](http://wiki.ivoa.net/twiki/bin/view/IVOA/IvoaVOEvent) | [archives](http://mail.ivoa.net/pipermail/voevent/) | [options](http://mail.ivoa.net/mailman/listinfo/voevent) | [voevent@ivoa.net](mailto:voevent@ivoa.net) | Judith Racusin | Pierre Fernique |
 {{</my-table>}}
+
+### Interest Groups in standby
+- [Theory](http://wiki.ivoa.net/twiki/bin/view/IVOA/IvoaTheory) ([archives](http://mail.ivoa.net/pipermail/theory/), [options](http://mail.ivoa.net/mailman/listinfo/theory)): group without formal coordination, write to [theory@ivoa.net](mailto:theory@ivoa.net).
+
 
 ## Other Groups, Activities and Committees
 {{<my-table>}}
 | Group/Committee Page | Previous Messages | Subscribe | Mailing List | Chair | Vice Chair |
 | --- | --- | --- | --- | --- | --- |
 | Interop | [archives](http://mail.ivoa.net/pipermail/interop/) | [options](http://mail.ivoa.net/mailman/listinfo/interop) | [interop@ivoa.net](mailto:interop@ivoa.net) | N/A | N/A |
-| [Exec](http://wiki.ivoa.net/twiki/bin/view/IVOA/IvoaRepMin) |  |  | [exec@ivoa.net](mailto:exec@ivoa.net) | Christophe Arviset | Simon O'Toole |
-| [Technical Coordination Group](http://wiki.ivoa.net/twiki/bin/view/IVOA/IvoaTCG) |  |  | [tcg@ivoa.net](mailto:tcg@ivoa.net) | Janet Evans | Marco Molinaro |
-| IAU-IVOA Liaison Committee |  |  |  | Bruce Berriman |  |
-| [Standing Committee on Science Priorities](http://wiki.ivoa.net/twiki/bin/view/IVOA/IvoaSciencePriorities) |  |  | [csp@ivoa.net](mailto:csp@ivoa.net) | Ada Nebot | Francesca Civano |
+| [Exec](http://wiki.ivoa.net/twiki/bin/view/IVOA/IvoaRepMin) |  |  | [exec@ivoa.net](mailto:exec@ivoa.net) | JJ Kavelaars | Mark Allen |
+| [Technical Coordination Group](http://wiki.ivoa.net/twiki/bin/view/IVOA/IvoaTCG) |  |  | [tcg@ivoa.net](mailto:tcg@ivoa.net) | Marco Molinaro | Tom Donaldson |
+| [IAU-IVOA Liaison Committee](https://wiki.ivoa.net/twiki/bin/view/IVOA/IvoaIauLiaison) |  |  |  | Bruce Berriman |  |
+| [Standing Committee on Science Priorities](http://wiki.ivoa.net/twiki/bin/view/IVOA/IvoaSciencePriorities) |  |  | [csp@ivoa.net](mailto:csp@ivoa.net) | Francesca Civano | Vandana Desai |
 | [Standing Committee on Standards & Processes](http://wiki.ivoa.net/twiki/bin/view/IVOA/IvoaStdsDocsProc) | [archives](http://mail.ivoa.net/pipermail/stdproc/) | [options](http://mail.ivoa.net/mailman/listinfo/stdproc) | stdproc@ivoa.net | Patrick Dowler | N/A |
 | IVOA Document Coordinator |  |  | [ivoadoc@ivoa.net](mailto:ivoadoc@ivoa.net) | Giulia Iafrate | N/A |
 {{</my-table>}}


### PR DESCRIPTION
Usually at the end of an interop some changes in roles happen.
This PR trues to cover them for the June 2025 Interop, including some extra fixes that went outdated since we initially ported the website to Hugo.